### PR TITLE
FCE-3327: Deploy to /var/www/gesture.fishjam.io instead of nginx package dir

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,4 +46,4 @@ jobs:
           rm: true
           strip_components: 1
           source: dist/*
-          target: /usr/share/nginx/html
+          target: /var/www/gesture.fishjam.io


### PR DESCRIPTION
The rest of required changes were made manually on the host